### PR TITLE
Change to "not verified" upon document changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## 1.7.0
+
+- Now changing status to *Not Verified* as soon as a document is edited.
+
 ## 1.6.0
 
 - Updated Dafny and language server to [v3.2.0](https://github.com/dafny-lang/dafny/releases/tag/v3.2.0)

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "dafny-vscode",
   "displayName": "Dafny",
   "description": "Dafny for Visual Studio Code",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "publisher": "correctnessLab",
   "homepage": "https://github.com/DafnyVSCode/",
   "repository": {

--- a/src/ui/providers/statusbarProvider.ts
+++ b/src/ui/providers/statusbarProvider.ts
@@ -1,6 +1,7 @@
 "use strict";
 import {
   window,
+  workspace,
   Uri,
   StatusBarItem,
   StatusBarAlignment,
@@ -65,6 +66,10 @@ export class StatusbarProvider implements IStatusbarProvider {
         this.update();
       }
     );
+
+    workspace.onDidChangeTextDocument(event => {
+      this.verificationMessage[event.document.uri.toString()] = StatusbarStrings.NotVerified;
+    });
   }
 
   public dispose(): void {


### PR DESCRIPTION
As requested in #32, this PR changes the verification status to *Not Verified* as soon as a document was changed, independently from the language server.